### PR TITLE
fix: improve styles for cta, card, and banner

### DIFF
--- a/src/components/atama/banner.tsx
+++ b/src/components/atama/banner.tsx
@@ -9,8 +9,6 @@ export function Banner({
   image,
   link,
   bannerTitleColor,
-  bannerSubtitleColor,
-  bannerDescriptionColor,
   atama,
 }: {
   title: string;
@@ -19,36 +17,28 @@ export function Banner({
   buttonText: string;
   image: string;
   link?: string;
-  bannerTitleColor: 'white' | 'black' | 'green' | 'yellow';
-  bannerSubtitleColor: 'white' | 'black' | 'green' | 'yellow';
-  bannerDescriptionColor: 'white' | 'black' | 'green' | 'yellow';
+  bannerTitleColor: 'white' | 'black';
   atama: object;
 }) {
   const colors = {
     white: 'text-white',
     black: 'text-black',
-    green: 'text-green-500',
-    yellow: 'text-yellow-500',
   };
 
   return (
-    <section className="w-full relative py-28 px-8 rounded" {...atama}>
-      <div className="z-10 relative w-full md:w-1/2 flex flex-col justify-center items-start gap-3">
-        <div className="grid gap-4">
-          <h2 className={clsx(colors[bannerSubtitleColor], 'uppercase')}>
-            {subtitle}
-          </h2>
-          <h1 className={clsx(colors[bannerTitleColor], 'uppercase text-4xl')}>
+    <section className="w-full relative py-28 px-8 rounded mb-4" {...atama}>
+      <div className="z-10 relative w-full md:w-1/2 flex flex-col justify-center items-start">
+        <div className="grid gap-4 bg-black/40 p-10">
+          <h2 className="text-sm	text-slate-300 uppercase">{subtitle}</h2>
+          <h1 className={clsx(colors[bannerTitleColor], 'text-4xl font-bold')}>
             {title}
           </h1>
-          <div className={clsx(colors[bannerDescriptionColor])}>
-            {description}
-          </div>
+          <div className="text-slate-300">{description}</div>
           {link && (
             <div>
               <Link
                 to={link}
-                className="uppercase bg-black text-white py-3 px-8 inline-block underline underline-offset-2 text-sm font-semibold"
+                className="bg-yellow-500 text-white py-3 px-6 inline-block text-md font-semibold"
               >
                 {buttonText}
               </Link>

--- a/src/components/atama/call-to-action.tsx
+++ b/src/components/atama/call-to-action.tsx
@@ -15,7 +15,7 @@ export function CallToAction({
   atama: object;
 }) {
   const backgroundColors = {
-    gray: 'bg-neutral-300 dark:bg-zinc-900 dark:border-2 dark:border-zinc-800 rounded',
+    gray: 'bg-neutral-300 dark:bg-zinc-900 dark:border-2 dark:border-zinc-700 rounded',
   };
 
   return (
@@ -27,8 +27,8 @@ export function CallToAction({
       {...atama}
     >
       <div className="grid gap-4">
-        <p className="font-bold text-4xl">{title}</p>
-        <p>{description}</p>
+        <p className="font-bold text-3xl">{title}</p>
+        <p className="text-slate-400">{description}</p>
       </div>
       <div className="flex items-center">
         <Button href="#">{buttonText}</Button>

--- a/src/components/atama/card.tsx
+++ b/src/components/atama/card.tsx
@@ -25,7 +25,7 @@ export function Card({
 
   return (
     <div
-      className="flex flex-col h-full dark:border-2 dark:border-zinc-800"
+      className="flex flex-col h-full dark:border-2 dark:border-zinc-700 rounded"
       {...atama}
     >
       <div className="card-image--top">
@@ -37,13 +37,16 @@ export function Card({
           className="object-cover w-full h-auto"
         />
       </div>
-      <div className="grid gap-4 bg-zinc-100 dark:bg-zinc-900 py-4 grow rounded-b">
-        <h2 className="text-center font-bold text-2xl px-4">{title}</h2>
-        <p className="px-4">{description}</p>
+      <div className="grid gap-4 bg-zinc-100 dark:bg-zinc-900 py-6 grow">
+        <h2 className="text-center font-bold text-2xl px-6">{title}</h2>
+        <p className="px-6 text-slate-400">{description}</p>
         <div className="flex justify-center content-start self-end">
           <Link
             to="#"
-            className={clsx(buttonColors[buttonBackground], 'py-3 px-8')}
+            className={clsx(
+              buttonColors[buttonBackground],
+              'py-2 px-4 font-semibold',
+            )}
           >
             {buttonText}
           </Link>

--- a/src/layouts/homepage.tsx
+++ b/src/layouts/homepage.tsx
@@ -27,7 +27,7 @@ export const Homepage = forwardRef<HTMLDivElement, HomepageProps>(
     },
     ref,
   ) => (
-    <div ref={ref} className="max-w-6xl mx-auto grid gap-4">
+    <div ref={ref} className="max-w-6xl mx-auto grid gap-4 mb-4">
       <div data-atama-placement="Top">{top}</div>
       <ThreeColumnsGrid>
         <ThreeColumnsGridItem data-atama-placement="Top Left">

--- a/src/layouts/landing-page.tsx
+++ b/src/layouts/landing-page.tsx
@@ -26,7 +26,7 @@ export const LandingPage = forwardRef<HTMLDivElement, LandingPageProps>(
     ref,
   ) => {
     return (
-      <div ref={ref} className="max-w-6xl mx-auto grid gap-4">
+      <div ref={ref} className="max-w-6xl mx-auto grid gap-4 mb-4">
         <div data-atama-placement="Top">{top}</div>
         <ThreeColumnsGrid>
           <ThreeColumnsGridItem data-atama-placement="Top Left">


### PR DESCRIPTION
The most significant change here is adding a background with an opacity of 40% on top of the image to make the copy readable. I've also removed some font color options because I don't think they're necessary.

![WNDR-s-Winter-Trips-2022-·-Hydrogen](https://user-images.githubusercontent.com/89743807/223247056-29799491-2435-4a22-bf2e-63b799c98c45.png)
![WNDR](https://user-images.githubusercontent.com/89743807/223247066-80e8fdef-b5c2-4bda-86f9-03ec591c0184.png)